### PR TITLE
fix: 유저 프로필 이미지 클릭 시 백준 이동 안되는 에러 수정

### DIFF
--- a/src/components/service/UserProfileImage/UserProfileImage.tsx
+++ b/src/components/service/UserProfileImage/UserProfileImage.tsx
@@ -22,33 +22,14 @@ const UserProfileImage = ({
   disabled = false,
   isLoading = false,
 }: UserProfileImageProps) => {
-  if (!user || !user.profileImageFileName) {
-    return (
-      <HStack
-        alignItems="center"
-        justifyContent="center"
-        style={{ position: 'relative', width: `${width}`, height: `${height}` }}
-      >
-        <S.ProfileImage
-          src={DefaultProfile}
-          width={width}
-          height={height}
-          backgroundColor={backgroundColor}
-          disabled={disabled}
-          isLoading={isLoading}
-        />
-        {isLoading && <LoadingIcon />}
-      </HStack>
-    );
-  }
-
   const handleClick = () => {
-    if (disabled || !user.baekjoonId) {
-      return;
-    }
-
+    if (disabled || !user?.baekjoonId) return;
     moveToBaekjoonProfileSite(user.baekjoonId);
   };
+
+  const profileImageUrl = user?.profileImageFileName
+    ? `${import.meta.env.VITE_USER_PROFILE_IMAGE_URL}/${user.profileImageFileName}`
+    : DefaultProfile;
 
   return (
     <HStack
@@ -57,7 +38,7 @@ const UserProfileImage = ({
       style={{ position: 'relative', width: `${width}`, height: `${height}` }}
     >
       <S.ProfileImage
-        src={`${import.meta.env.VITE_USER_PROFILE_IMAGE_URL}/${user.profileImageFileName}`}
+        src={profileImageUrl}
         width={width}
         height={height}
         backgroundColor={backgroundColor}


### PR DESCRIPTION
## 변경 사항 설명
유저 프로필 이미지 클릭 시, 프로필 이미지가 없어서 백준 이동이 안되는 에러를 수정했습니다.

## 체크리스트
- [x] 에러 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 사용자 정보가 없거나 프로필 이미지 파일명이 없는 경우에도 기본 프로필 이미지가 올바르게 표시됩니다.

- **리팩터링**
  - 프로필 이미지 렌더링 로직이 일관되게 동작하도록 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->